### PR TITLE
feat: add custom className feature for react-table

### DIFF
--- a/packages/react-table/src/components/DataTable.tsx
+++ b/packages/react-table/src/components/DataTable.tsx
@@ -22,7 +22,11 @@ const DefaultEmpty = () => (
 );
 
 type Props<T> = {
-  columns: Column<Record<string, T>>[];
+  columns: (Column<Record<string, T>> & {
+    className?: string,
+    headerClassName?: string,
+    cellClassName?: string
+  })[];
   data: T[];
   sort?: Sort;
   onSortChange?: (value: Sort) => void;
@@ -96,7 +100,16 @@ const DataTable = <T extends Record<string, any>>({
                 >
                   {headerGroup.headers.map(column => (
                     <div
-                      {...column.getHeaderProps()}
+                      {...column.getHeaderProps({
+                        className: classNames(
+                          (
+                            column as unknown as { className?: string }
+                          )?.className,
+                          (
+                            column as unknown as { headerClassName?: string}
+                          )?.headerClassName
+                        )
+                      })}
                       onClick={() => handleSortChange(column.id)}
                       key={column.id}
                       role="button"
@@ -148,9 +161,15 @@ const DataTable = <T extends Record<string, any>>({
                     >
                       {row.cells.map((cell, index) => (
                         <div
-                          {...cell.getCellProps()}
+                          {...cell.getCellProps({
+                            className: classNames("px-6 py-4 whitespace-nowrap text-sm text-gray-500 truncate", 
+                            (cell.column as unknown as { className?: string })
+                            ?.className,
+                            (cell.column as unknown as { cellClassName?: string })
+                            ?.cellClassName
+                            )
+                          })}
                           key={index}
-                          className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 truncate "
                         >
                           {cell.render('Cell')}
                         </div>

--- a/packages/react-table/src/components/DataTable.tsx
+++ b/packages/react-table/src/components/DataTable.tsx
@@ -141,7 +141,6 @@ const DataTable = <T extends Record<string, any>>({
 
             <div
               {...getTableBodyProps({ className: bodyClassName })}
-              className=" "
             >
               {rows.length === 0 ? (
                 Empty ? (

--- a/packages/react-table/tests/DataTable.test.tsx
+++ b/packages/react-table/tests/DataTable.test.tsx
@@ -41,4 +41,53 @@ describe('components/DataTable', () => {
     });
     expect(onSortChange).toBeCalledTimes(1);
   });
+
+
+  test("should render column header & cell with custom className", () => {
+    const screen = render(<DataTable  columns={[
+      {
+        Header: "header",
+        accessor: "a",
+        className: "test"
+      }
+    ]} data={[
+      {a: "test"}
+    ]} />)
+    const headerCell = screen.getByRole("button")
+    expect(headerCell).toHaveClass("test")
+    const bodyCell = screen.getByRole("cell")
+    expect(bodyCell).toHaveClass("test")
+  })
+
+  test("should render column header with headerClassName", () => {
+    const screen = render(<DataTable  columns={[
+      {
+        Header: "header",
+        accessor: "a",
+        headerClassName: "test"
+      }
+    ]} data={[
+      {a: "test"}
+    ]} />)
+    const headerCell = screen.getByRole("button")
+    expect(headerCell).toHaveClass("test")
+    const bodyCell = screen.getByRole("cell")
+    expect(bodyCell).not.toHaveClass("test")
+  })
+
+  test("should render column cell with cellClassName", () => {
+    const screen = render(<DataTable  columns={[
+      {
+        Header: "header",
+        accessor: "a",
+        cellClassName: "test"
+      }
+    ]} data={[
+      {a: "test"}
+    ]} />)
+    const headerCell = screen.getByRole("button")
+    expect(headerCell).not.toHaveClass("test")
+    const bodyCell = screen.getByRole("cell")
+    expect(bodyCell).toHaveClass("test")
+  })
 });

--- a/packages/react-table/tests/DataTable.test.tsx
+++ b/packages/react-table/tests/DataTable.test.tsx
@@ -42,52 +42,72 @@ describe('components/DataTable', () => {
     expect(onSortChange).toBeCalledTimes(1);
   });
 
+  test('add bodyClassName should work on rowgroup', () => {
+    const screen = render(
+      <DataTable
+        columns={MockReactTableColumns}
+        data={MockMembers}
+        bodyClassName="test-class"
+      />
+    );
+    const rowGroup = screen.getByRole('rowgroup');
+    expect(rowGroup).toHaveClass('test-class');
+  });
 
-  test("should render column header & cell with custom className", () => {
-    const screen = render(<DataTable  columns={[
-      {
-        Header: "header",
-        accessor: "a",
-        className: "test"
-      }
-    ]} data={[
-      {a: "test"}
-    ]} />)
-    const headerCell = screen.getByRole("button")
-    expect(headerCell).toHaveClass("test")
-    const bodyCell = screen.getByRole("cell")
-    expect(bodyCell).toHaveClass("test")
-  })
+  test('should render column header & cell with custom className', () => {
+    const screen = render(
+      <DataTable
+        columns={[
+          {
+            Header: 'header',
+            accessor: 'a',
+            className: 'test',
+          },
+        ]}
+        data={[{ a: 'test' }]}
+      />
+    );
+    const headerCell = screen.getByRole('button');
+    expect(headerCell).toHaveClass('test');
+    const bodyCell = screen.getByRole('cell');
+    expect(bodyCell).toHaveClass('test');
+  });
 
-  test("should render column header with headerClassName", () => {
-    const screen = render(<DataTable  columns={[
-      {
-        Header: "header",
-        accessor: "a",
-        headerClassName: "test"
-      }
-    ]} data={[
-      {a: "test"}
-    ]} />)
-    const headerCell = screen.getByRole("button")
-    expect(headerCell).toHaveClass("test")
-    const bodyCell = screen.getByRole("cell")
-    expect(bodyCell).not.toHaveClass("test")
-  })
+  test('should render column header with headerClassName', () => {
+    const screen = render(
+      <DataTable
+        columns={[
+          {
+            Header: 'header',
+            accessor: 'a',
+            headerClassName: 'test',
+          },
+        ]}
+        data={[{ a: 'test' }]}
+      />
+    );
+    const headerCell = screen.getByRole('button');
+    expect(headerCell).toHaveClass('test');
+    const bodyCell = screen.getByRole('cell');
+    expect(bodyCell).not.toHaveClass('test');
+  });
 
-  test("should render column cell with cellClassName", () => {
-    const screen = render(<DataTable  columns={[
-      {
-        Header: "header",
-        accessor: "a",
-        cellClassName: "test"
-      }
-    ]} data={[
-      {a: "test"}
-    ]} />)
-    const headerCell = screen.getByRole("button")
-    expect(headerCell).not.toHaveClass("test")
-    const bodyCell = screen.getByRole("cell")
-    expect(bodyCell).toHaveClass("test")
-  })
+  test('should render column cell with cellClassName', () => {
+    const screen = render(
+      <DataTable
+        columns={[
+          {
+            Header: 'header',
+            accessor: 'a',
+            cellClassName: 'test',
+          },
+        ]}
+        data={[{ a: 'test' }]}
+      />
+    );
+    const headerCell = screen.getByRole('button');
+    expect(headerCell).not.toHaveClass('test');
+    const bodyCell = screen.getByRole('cell');
+    expect(bodyCell).toHaveClass('test');
+  });
 });


### PR DESCRIPTION
https://github.com/TanStack/table/issues/1612

react-table 推荐使用这种方式来自定义 header/cell 的 className，定义在 columns 中。

但是并没有很好的 typescript 支持，他们写的例子都是 js 版本